### PR TITLE
Only replace global variables

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,13 @@
 export default ({types: t}) => ({
   visitor: {
     Identifier(path, state) {
-      const replacement = state.opts[path.node.name]
       if (path.parent.type === 'MemberExpression') {
         return;
       }
+      if (path.isPure()) {
+        return;
+      }
+      const replacement = state.opts[path.node.name]
       if (replacement !== undefined) {
         const type = typeof replacement
         if (type === 'boolean') {

--- a/test/test.js
+++ b/test/test.js
@@ -59,3 +59,25 @@ if (foo.bar.__SERVER__) {
     });
 
 });
+
+describe('non-globals', () => {
+    describe(`transform`, () => {
+        it(`__SERVER__ should NOT be replaced to true`, () => {
+            babel.transform(`
+                function foo(__SERVER__) {
+                    console.log('this is a normal argument', __SERVER__)
+                }
+            `, {
+                plugins: [[plugin, {
+                    __SERVER__: true,
+                    __VERSION__: "v1.2.3"
+                }]]
+            }).code
+              .should.be.equal(`
+function foo(__SERVER__) {
+    console.log('this is a normal argument', __SERVER__);
+}`)
+        });
+    });
+
+});


### PR DESCRIPTION
If a matching identifier is in scope, it shouldn't be replaced.